### PR TITLE
get all task execute result when Dexecutor completed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ buildNumber.properties
 .classpath
 .settings
 .project
+.idea/

--- a/src/main/java/com/github/dexecutor/core/DefaultDexecutor.java
+++ b/src/main/java/com/github/dexecutor/core/DefaultDexecutor.java
@@ -24,7 +24,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
-import com.sun.tools.javac.util.Pair;
+import javafx.util.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -141,7 +141,7 @@ public class DefaultDexecutor <T, R> implements Dexecutor<T, R> {
 	}
 
 	public List<Pair<T,R>> getAllProcessedResult() {
-		return this.state.getProcessedNodes().stream().map(n -> Pair.of(n.getValue(), n.getResult())).collect(Collectors.toList());
+		return this.state.getProcessedNodes().stream().map(n -> new Pair<T, R>(n.getValue(), n.getResult())).collect(Collectors.toList());
 	}
 
 	private void shutdownExecutors() {

--- a/src/main/java/com/github/dexecutor/core/DefaultDexecutor.java
+++ b/src/main/java/com/github/dexecutor/core/DefaultDexecutor.java
@@ -17,15 +17,14 @@
 
 package com.github.dexecutor.core;
 
-import java.util.Collection;
-import java.util.Date;
-import java.util.HashSet;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
+import com.sun.tools.javac.util.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -137,8 +136,12 @@ public class DefaultDexecutor <T, R> implements Dexecutor<T, R> {
 
 		logger.debug("Total Time taken to process {} jobs is {} ms.", this.state.graphSize(), end - start);
 		logger.debug("Processed Nodes Ordering {}", this.state.getProcessedNodes());
-		
+
 		return this.state.getErrored();
+	}
+
+	public List<Pair<T,R>> getAllProcessedResult() {
+		return this.state.getProcessedNodes().stream().map(n -> Pair.of(n.getValue(), n.getResult())).collect(Collectors.toList());
 	}
 
 	private void shutdownExecutors() {

--- a/src/main/java/com/github/dexecutor/core/Dexecutor.java
+++ b/src/main/java/com/github/dexecutor/core/Dexecutor.java
@@ -21,6 +21,9 @@ import com.github.dexecutor.core.graph.DependencyAware;
 import com.github.dexecutor.core.graph.Traversar;
 import com.github.dexecutor.core.graph.TraversarAction;
 import com.github.dexecutor.core.task.ExecutionResults;
+import com.sun.tools.javac.util.Pair;
+
+import java.util.List;
 
 /**
  * Main Interface for Dexecutor framework, It provides api to build the graph and and to kick off the execution.
@@ -41,6 +44,12 @@ public interface Dexecutor<T, R> extends DependencyAware<T> {
 	 * @return {@link ExecutionResults} the results
 	 */
 	ExecutionResults<T, R> execute(final ExecutionConfig config);
+
+	/**
+	 * get all processed task execute result list
+	 * @return all task execute result
+	 */
+	public List<Pair<T,R>> getAllProcessedResult();
 
 	/**
 	 * After a dexecutor crash, create a new instance of dexecutor and call this method for recovery

--- a/src/main/java/com/github/dexecutor/core/Dexecutor.java
+++ b/src/main/java/com/github/dexecutor/core/Dexecutor.java
@@ -21,7 +21,7 @@ import com.github.dexecutor.core.graph.DependencyAware;
 import com.github.dexecutor.core.graph.Traversar;
 import com.github.dexecutor.core.graph.TraversarAction;
 import com.github.dexecutor.core.task.ExecutionResults;
-import com.sun.tools.javac.util.Pair;
+import javafx.util.Pair;
 
 import java.util.List;
 

--- a/src/main/java/com/github/dexecutor/core/graph/Node.java
+++ b/src/main/java/com/github/dexecutor/core/graph/Node.java
@@ -46,7 +46,7 @@ public final class Node<T, R> implements Serializable {
 	 */
 	private NodeStatus status;
 	/**
-	 * Arbitray data of this node
+	 * Arbitrary data of this node
 	 */
 	private Object data;
 	/**

--- a/src/test/java/com/github/dexecutor/core/DexecutorTest.java
+++ b/src/test/java/com/github/dexecutor/core/DexecutorTest.java
@@ -18,13 +18,16 @@
 package com.github.dexecutor.core;
 
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
+import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
+import com.sun.tools.javac.util.Pair;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -106,7 +109,19 @@ public class DexecutorTest {
 
 		executor.execute(ExecutionConfig.TERMINATING);
 	}
-	
+
+  @Test
+  public void testGetAllProcessedResult() {
+    DefaultDexecutor<Integer, Integer> executor = newTaskExecutor(false);
+    executor.addDependency(1, 2);
+    executor.addDependency(1, 3);
+    executor.execute(new ExecutionConfig().scheduledRetrying(1, new Duration(1, TimeUnit.SECONDS)));
+    List<Pair<Integer, Integer>> allResult = executor.getAllProcessedResult();
+    assertEquals("size of task execute result should be 3", 3, allResult.size());
+    allResult.forEach(pair ->
+      assertEquals(pair.fst + "st task execute result should be " + pair.fst, pair.fst, pair.snd)
+    );
+  }
 	
 	private DefaultDexecutor<Integer, Integer> newTaskExecutor() {
 		DexecutorConfig<Integer, Integer> config = new DexecutorConfig<>(newExecutor(), new DummyTaskProvider(false));

--- a/src/test/java/com/github/dexecutor/core/DexecutorTest.java
+++ b/src/test/java/com/github/dexecutor/core/DexecutorTest.java
@@ -27,7 +27,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
-import com.sun.tools.javac.util.Pair;
+import javafx.util.Pair;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -119,7 +119,7 @@ public class DexecutorTest {
     List<Pair<Integer, Integer>> allResult = executor.getAllProcessedResult();
     assertEquals("size of task execute result should be 3", 3, allResult.size());
     allResult.forEach(pair ->
-      assertEquals(pair.fst + "st task execute result should be " + pair.fst, pair.fst, pair.snd)
+      assertEquals(pair.getKey() + "st task execute result should be " + pair.getKey(), pair.getKey(), pair.getValue())
     );
   }
 	


### PR DESCRIPTION
The class `Dexecutor.execute()` return `ExecutionResults<T, R>` which actually error result
```
    ExecutionResults<T, R> execute(final ExecutionConfig config);
```
so I add a method to get all proccessed task execute result 
```
    List<Pair<T,R>> getAllProcessedResult();
```